### PR TITLE
Generate bootable USB image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.elf
 *.iso
+*.img
 iso
 config.mk

--- a/Makefile
+++ b/Makefile
@@ -54,8 +54,15 @@ iso/boot/grub/menu.lst: menu.lst
 	@mkdir -p iso/boot/grub
 	cp $< $@
 
+IMG = tetrasm.img
+img: $(IMG)
+
+$(IMG): tetrasm.elf isodir/boot/grub/grub.cfg
+	cp tetrasm.elf isodir/boot
+	grub-mkrescue -o '$@' isodir
+
 clean:
-	rm -rf $(ISO) iso $(KERNEL) $(OBJECTS)
+	rm -rf $(ISO) iso $(KERNEL) $(OBJECTS) $(IMG) isodir/boot/*.elf
 
 # Emulation
 
@@ -72,6 +79,9 @@ qemu: $(KERNEL)
 qemu-iso: $(ISO)
 	$(QEMU) $(QEMU_FLAGS) -cdrom $<
 
+qemu-img: $(IMG)
+	$(QEMU) $(QEMU_FLAGS) -hda $<
+
 # Debugger
 
 GDB = gdb
@@ -82,4 +92,4 @@ gdb: $(KERNEL)
 
 -include config.mk
 
-.PHONY: kernel iso clean qemu qemu-iso gdb
+.PHONY: kernel iso clean qemu qemu-iso gdb img

--- a/isodir/boot/grub/grub.cfg
+++ b/isodir/boot/grub/grub.cfg
@@ -1,0 +1,5 @@
+set timeout=0
+set default="0"
+menuentry "main" {
+	multiboot /boot/tetrasm.elf
+}


### PR DESCRIPTION
```
sudo apt-get install build-essential gnu-efi qemu xorriso
make qemu-img
```

tests it on the emulator.

Then:

```
sudo dd if=tetrasm.img of=/dev/sdX
```

burn to a USB and plug it on a computer it works. Tested OK on a Lenovo T400. On Mac Air display worsk, but keyboard input does not, maybe linked to EFI?

I have posted a minimal example of `grub-mkrescue` at: https://github.com/cirosantilli/x86-bare-metal-examples/tree/38c30d5bc06aabd2006b8191e38229e691170a3c/multiboot/hello-world It is the exact same technique as this PR, so should be useful to reproduce.

This uses `grub-mkrescue` to do the job. It should also work if you burn it to a CD: https://www.gnu.org/software/grub/manual/html_node/Invoking-grub_002dmkrescue.html

This is a minimal PR. If you like this, I also propose the following future change which I might PR myself:
- remove current ISO generation and use only QEMU.
- remove the `stage2_eltorito` blob. It is easily obtained from package managers and used with QEMU
- document the USB method
